### PR TITLE
docs: correct plug-ins documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use [npm](https://www.npmjs.com/), the [Node.js](https://nodejs.org/en/) package
 npm install
 ```
 
-To make the Camunda Modeler aware of your plugin you must link the plugin to the [Camunda Modeler plugin directory](https://github.com/camunda/camunda-modeler/tree/develop/docs/plugins#plugging-into-the-camunda-modeler) via a symbolic link.
+To make the Camunda Modeler aware of your plugin you must link the plugin to the [Camunda Modeler plugin directory](https://docs.camunda.io/docs/components/modeler/desktop-modeler/plugins/#plugging-into-camunda-modeler) via a symbolic link.
 Available utilities to do that are [`mklink /d`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink) on Windows and [`ln -s`](https://linux.die.net/man/1/ln) on MacOS / Linux.
 
 Re-start the app in order to recognize the newly linked plugin.


### PR DESCRIPTION
Fixes a broken link